### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Contributor Code of Conduct
+## Our Purpose
+In hopes of creating a community that can actively work towards a common goal, we as contributors hereby pledge to make participation in our project a pleasant experience for all. Harassment will not be tolerated as everyone is accepted in this community, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+Examples of behavior that is encouraged:
+
+* Using positive and inclusive language.
+* Being respectful to everyone, regardless the circumstance.
+* Promoting collaboration and constructive criticism where applicable.
+* Putting the community over the individual.
+* Being empathetic to every member of the community.
+
+Examples of behavior that is not tolerated:
+
+* Any actions that can be deemed sexual.
+* Any actions that can be insulting to members of the community.
+* Any actions that can be seen as harassment, either publicly or privately.
+* Any actions that can be interpreted as inappropriate.
+* Divulging information on others without their consent.
+
+## Our Responsibilities
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+Project contributors are resposinble for making sure their contributions to the project align with the values and standards set forth.
+
+## Scope
+This Code of Conduct applies to all contributors, whether public or privately so long as they are acting at the behest of the project. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project owners. These reports will be reviewed and investigated, followed by an adequate response to the situation. The project owners will maintain confidentiality with regard to the reporter of an incident.
+
+Project contributors who do not follow or enforce the Code of Conduct in good faith will be punished accordingly by the project owners.


### PR DESCRIPTION
Documentation added for Open Source class. A lack of a code of conduct allowed for a meaningful contribution.