### PR TITLE
Add additional video tutorial reference to documentation.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Welcome to Spotipy!
 you get full access to all of the music data provided by the Spotify platform.
 
 Assuming you set the ``SPOTIPY_CLIENT_ID`` and ``SPOTIPY_CLIENT_SECRET``
-environment variables (here is a `video <https://youtu.be/3RGm4jALukM>`_ explaining how to do so). For a longer tutorial with examples included, refer to this video playlist [here](https://www.youtube.com/watch?v=tmt5SdvTqUI&list=PLqgOPibB_QnzzcaOFYmY2cQjs35y0is9N&index=1) Below is a quick example of using *Spotipy* to list the
+environment variables (here is a `video <https://youtu.be/3RGm4jALukM>`_ explaining how to do so). For a longer tutorial with examples included, refer to this video playlist `video <https://www.youtube.com/watch?v=tmt5SdvTqUI&list=PLqgOPibB_QnzzcaOFYmY2cQjs35y0is9N&index=1>`_ Below is a quick example of using *Spotipy* to list the
 names of all the albums released by the artist 'Birdy'::
 
     import spotipy

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Welcome to Spotipy!
 you get full access to all of the music data provided by the Spotify platform.
 
 Assuming you set the ``SPOTIPY_CLIENT_ID`` and ``SPOTIPY_CLIENT_SECRET``
-environment variables (here is a `video <https://youtu.be/3RGm4jALukM>`_ explaining how to do so), here's a quick example of using *Spotipy* to list the
+environment variables (here is a `video <https://youtu.be/3RGm4jALukM>`_ explaining how to do so). For a longer tutorial with examples included, refer to this video playlist `here <https://www.youtube.com/watch?v=tmt5SdvTqUI&list=PLqgOPibB_QnzzcaOFYmY2cQjs35y0is9N&index=1>` Below is a quick example of using *Spotipy* to list the
 names of all the albums released by the artist 'Birdy'::
 
     import spotipy

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Welcome to Spotipy!
 you get full access to all of the music data provided by the Spotify platform.
 
 Assuming you set the ``SPOTIPY_CLIENT_ID`` and ``SPOTIPY_CLIENT_SECRET``
-environment variables (here is a `video <https://youtu.be/3RGm4jALukM>`_ explaining how to do so). For a longer tutorial with examples included, refer to this video playlist `video <https://www.youtube.com/watch?v=tmt5SdvTqUI&list=PLqgOPibB_QnzzcaOFYmY2cQjs35y0is9N&index=1>`_ Below is a quick example of using *Spotipy* to list the
+environment variables (here is a `video <https://youtu.be/3RGm4jALukM>`_ explaining how to do so). For a longer tutorial with examples included, refer to this `video playlist <https://www.youtube.com/watch?v=tmt5SdvTqUI&list=PLqgOPibB_QnzzcaOFYmY2cQjs35y0is9N&index=1>`_. Below is a quick example of using *Spotipy* to list the
 names of all the albums released by the artist 'Birdy'::
 
     import spotipy

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Welcome to Spotipy!
 you get full access to all of the music data provided by the Spotify platform.
 
 Assuming you set the ``SPOTIPY_CLIENT_ID`` and ``SPOTIPY_CLIENT_SECRET``
-environment variables (here is a `video <https://youtu.be/3RGm4jALukM>`_ explaining how to do so). For a longer tutorial with examples included, refer to this video playlist `here <https://www.youtube.com/watch?v=tmt5SdvTqUI&list=PLqgOPibB_QnzzcaOFYmY2cQjs35y0is9N&index=1>` Below is a quick example of using *Spotipy* to list the
+environment variables (here is a `video <https://youtu.be/3RGm4jALukM>`_ explaining how to do so). For a longer tutorial with examples included, refer to this video playlist [here](https://www.youtube.com/watch?v=tmt5SdvTqUI&list=PLqgOPibB_QnzzcaOFYmY2cQjs35y0is9N&index=1) Below is a quick example of using *Spotipy* to list the
 names of all the albums released by the artist 'Birdy'::
 
     import spotipy


### PR DESCRIPTION
Simply a suggestion to add an additional link to video tutorial series by Ian Annase. Found [here](https://www.youtube.com/watch?v=tmt5SdvTqUI&list=PLqgOPibB_QnzzcaO).
The currently included tutorial is very low resolution (360p) and covers less detail. Including the new tutorial as well would provide clearer video instruction.