### PR TITLE
Ignore Attribute error in Spotify.__del__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changes the YouTube video link for authentication tutorial (the old video was in low definition, the new one is in high definition)
 - Updated links to Spotify in documentation 
-- Fixed error obfuscation when Spotify class is being inherited and an error is raised in the Child's __init__
+- Fixed error obfuscation when Spotify class is being inherited and an error is raised in the Child's `__init__`
 
 ## [2.23.0] - 2023-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changes the YouTube video link for authentication tutorial (the old video was in low definition, the new one is in high definition)
 - Updated links to Spotify in documentation 
+- Fixed error obfuscation when Spotify class is being inherited and an error is raised in the Child's __init__
 
 ## [2.23.0] - 2023-04-07
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -211,8 +211,11 @@ class Spotify(object):
 
     def __del__(self):
         """Make sure the connection (pool) gets closed"""
-        if isinstance(self._session, requests.Session):
-            self._session.close()
+        try:
+            if isinstance(self._session, requests.Session):
+                self._session.close()
+        except AttributeError:
+            pass
 
     def _build_session(self):
         self._session = requests.Session()


### PR DESCRIPTION
I was trying to create a class that Inherits spotipy.Spotify. But found this interaction where if an exception is raised in the child class's `__init__` it will try to run `Spotify.__del__` where `self._session` hasn't been defined yet. So it raises an Attribute Error instead of the Exception from the child class.
 

For example
```
from spotipy import Spotify


class Spotify2(Spotify):
    def __init__(self):
        raise Exception
    

spotify_instance = Spotify2()
```
Will result in this error ignoring the Exception raised in the child class's `__init__`
```
Traceback (most recent call last):
  File "/Users/Me/Desktop/test.py", line 22, in <module>
    spotify_instance = Spotify2()
  File "/Users/Me/Desktop/test.py", line 19, in __init__
    raise Exception
Exception
Exception ignored in: <function Spotify.__del__ at 0x101b7df70>
Traceback (most recent call last):
  File "/Users/Me/.pyenv/versions/3.9.15/lib/python3.9/site-packages/spotipy/client.py", line 214, in __del__
    if isinstance(self._session, requests.Session):
AttributeError: 'Spotify2' object has no attribute '_session'
```