### PR TITLE
Addressed issue #936

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changes the YouTube video link for authentication tutorial (the old video was in low definition, the new one is in high definition)
 - Updated links to Spotify in documentation 
 
+## [2.23.1] - 2023-10-30
+
+### Added
+
+- Added an additional FAQ addressing the hidden limit of 50 shows per request for the API endpoints related to accessing/adding/deleting current user saved shows suffixed by "current_user_saved_shows" in client.py, resulting in an unexplained HTTP error response.
+
 ## [2.23.0] - 2023-04-07
 
 ### Added

--- a/FAQ.md
+++ b/FAQ.md
@@ -52,3 +52,7 @@ If you cannot open a browser, set `open_browser=False` when instantiating Spotif
 prompted to open the authorization URI manually.  
 
 See the [headless auth example](examples/headless.py).
+
+### Howcome I have trouble accessing/adding/deleting more than 50 current user saved shows?
+
+If you are running into issues with any of these services in the family of functions suffixed with "current_user_saved_shows" in the client.py file such as an HTTP error response, that is because Spotify imposes a hidden limit to the number of shows you can access/add/delete to 50 in a single request. A quick recommended workout solution is to limit the amount to 50 shows or lower in a single request or call to one of those functions


### PR DESCRIPTION
Added an additional FAQ addressing the hidden limit of 50 shows per request for the API endpoints related to accessing/adding/deleting current user saved shows suffixed by "current_user_saved_shows" in client.py, resulting in an unexplained HTTP error response.

https://github.com/spotipy-dev/spotipy/issues/936