### PR TITLE
Issue 1051

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changes the YouTube video link for authentication tutorial (the old video was in low definition, the new one is in high definition)
 - Updated links to Spotify in documentation 
 
-## [2.23.1] - 2023-10-30
-
-### Added
-
-- Added an additional FAQ addressing the hidden limit of 50 shows per request for the API endpoints related to accessing/adding/deleting current user saved shows suffixed by "current_user_saved_shows" in client.py, resulting in an unexplained HTTP error response.
-
 ## [2.23.0] - 2023-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changes the YouTube video link for authentication tutorial (the old video was in low definition, the new one is in high definition)
 - Updated links to Spotify in documentation 
 
-
-## [2.23.1] - 2023-12-09
-
 ### Fixed
 - Seperated the test_current_user_save_and_usave_tracks unit test into test_current_user_save_tracks and test_current_user_unsave_tracks in the user endpoint test suite to improve unit test clarity and effectiveness for their respective user endpoints methods (current_user_saved_tracks_add, current_user_saved_tracks).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changes the YouTube video link for authentication tutorial (the old video was in low definition, the new one is in high definition)
 - Updated links to Spotify in documentation 
 
+## [2.23.1] - 2023-10-30
+
+### Added
+
+- Added an additional FAQ addressing the hidden limit of 50 shows per request for the API endpoints related to accessing/adding/deleting current user saved shows suffixed by "current_user_saved_shows" in client.py, resulting in an unexplained HTTP error response.
+
 ## [2.23.0] - 2023-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changes the YouTube video link for authentication tutorial (the old video was in low definition, the new one is in high definition)
 - Updated links to Spotify in documentation 
 
+
+## [2.23.1] - 2023-12-09
+
+### Fixed
+- Seperated the test_current_user_save_and_usave_tracks unit test into test_current_user_save_tracks and test_current_user_unsave_tracks in the user endpoint test suite to improve unit test clarity and effectiveness for their respective user endpoints methods (current_user_saved_tracks_add, current_user_saved_tracks).
+
 ## [2.23.0] - 2023-04-07
 
 ### Added

--- a/FAQ.md
+++ b/FAQ.md
@@ -52,3 +52,7 @@ If you cannot open a browser, set `open_browser=False` when instantiating Spotif
 prompted to open the authorization URI manually.  
 
 See the [headless auth example](examples/headless.py).
+
+### Howcome I have trouble accessing/adding/deleting more than 50 current user saved shows?
+
+If you are running into issues with any of these services in the family of functions suffixed with "current_user_saved_shows" in the client.py file such as an HTTP error response, that is because Spotify imposes a hidden limit to the number of shows you can access/add/delete to 50 in a single request. A quick recommended workout solution is to limit the amount to 50 shows or lower in a single request or call to one of those functions

--- a/FAQ.md
+++ b/FAQ.md
@@ -52,7 +52,3 @@ If you cannot open a browser, set `open_browser=False` when instantiating Spotif
 prompted to open the authorization URI manually.  
 
 See the [headless auth example](examples/headless.py).
-
-### Howcome I have trouble accessing/adding/deleting more than 50 current user saved shows?
-
-If you are running into issues with any of these services in the family of functions suffixed with "current_user_saved_shows" in the client.py file such as an HTTP error response, that is because Spotify imposes a hidden limit to the number of shows you can access/add/delete to 50 in a single request. A quick recommended workout solution is to limit the amount to 50 shows or lower in a single request or call to one of those functions

--- a/tests/integration/user_endpoints/test.py
+++ b/tests/integration/user_endpoints/test.py
@@ -253,7 +253,7 @@ class SpotipyLibraryApiTests(unittest.TestCase):
         tracks = self.spotify.current_user_saved_tracks()
         self.assertGreaterEqual(len(tracks['items']), 0)
 
-    def test_current_user_save_and_unsave_tracks(self):
+    def test_current_user_save_tracks(self):
         tracks = self.spotify.current_user_saved_tracks()
         total = tracks['total']
         self.spotify.current_user_saved_tracks_add(self.four_tracks)
@@ -261,6 +261,19 @@ class SpotipyLibraryApiTests(unittest.TestCase):
         tracks = self.spotify.current_user_saved_tracks()
         new_total = tracks['total']
         self.assertEqual(new_total - total, len(self.four_tracks))
+
+        self.spotify.current_user_saved_tracks_delete(
+            self.four_tracks)
+        tracks = self.spotify.current_user_saved_tracks()
+        new_total = tracks['total']
+
+    def test_current_user_unsave_tracks(self):
+        tracks = self.spotify.current_user_saved_tracks()
+        total = tracks['total']
+        self.spotify.current_user_saved_tracks_add(self.four_tracks)
+
+        tracks = self.spotify.current_user_saved_tracks()
+        new_total = tracks['total']
 
         self.spotify.current_user_saved_tracks_delete(
             self.four_tracks)


### PR DESCRIPTION
Fixed:
- Seperated the test_current_user_save_and_usave_tracks unit test into test_current_user_save_tracks and test_current_user_unsave_tracks in the user endpoint test suite to improve unit test clarity and effectiveness for their respective user endpoints methods (current_user_saved_tracks_add, current_user_saved_tracks).
