### PR TITLE
Fix unused description parameter in playlist creation example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated links to Spotify in documentation
 - Improve usability on README.md
 
+### Fixed
+- Fixed unused description parameter in playlist creation example
+
 ## [2.23.0] - 2023-04-07
 
 ### Added

--- a/examples/create_playlist.py
+++ b/examples/create_playlist.py
@@ -24,7 +24,7 @@ def main():
     scope = "playlist-modify-public"
     sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
     user_id = sp.me()['id']
-    sp.user_playlist_create(user_id, args.playlist)
+    sp.user_playlist_create(user_id, args.playlist, description=args.description)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The playlist creation example outlines an optional argument, `--description`, but that parameter is never used within the script. This PR fixes that by adding the description into the `user_playlist_create` method call.