### PR TITLE
Updated _regex_spotify_url to ignore /intl-<countrycode> in Spotify links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changes the YouTube video link for authentication tutorial (the old video was in low definition, the new one is in high definition)
 - Updated links to Spotify in documentation
 - Improve usability on README.md
+- Updated _regex_spotify_url to ignore `/intl-<countrycode>` in Spotify links
 
 ## [2.23.0] - 2023-04-07
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -118,7 +118,7 @@ class Spotify(object):
     # instead of a more complex URL parsing function.
     #
     # [1] https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids
-    _regex_spotify_url = r'^(http[s]?:\/\/)?open.spotify.com\/(?P<type>track|artist|album|playlist|show|episode|user|audiobook)\/(?P<id>[0-9A-Za-z]+)(\?.*)?$'  # noqa: E501
+    _regex_spotify_url = r'^(http[s]?:\/\/)?open.spotify.com\/(intl-\w\w\/)?(?P<type>track|artist|album|playlist|show|episode|user|audiobook)\/(?P<id>[0-9A-Za-z]+)(\?.*)?$'  # noqa: E501
 
     _regex_base62 = r'^[0-9A-Za-z]+$'
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -117,7 +117,7 @@ class Spotify(object):
     # pointing to open.spotify.com, so a regex is used to parse them as well,
     # instead of a more complex URL parsing function.
     # Spotify recently added "/intl-<countrycode>" to their links. This change is undocumented.
-    # There is an assumption that the country code uses the ISO 3166-1 alpha-2 standard [2], 
+    # There is an assumption that the country code uses the ISO 3166-1 alpha-2 standard [2],
     # but this has not been confirmed yet. Spotipy has no use for this, so it gets ignored.
     #
     # [1] https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -110,14 +110,18 @@ class Spotify(object):
     # numbers and even older ones seemed to have been allowed to freely pick this name.
     #
     # [1] https://www.iana.org/assignments/uri-schemes/prov/spotify
-    # [2] https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids
+    # [2] https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
     _regex_spotify_uri = r'^spotify:(?:(?P<type>track|artist|album|playlist|show|episode|audiobook):(?P<id>[0-9A-Za-z]+)|user:(?P<username>[0-9A-Za-z]+):playlist:(?P<playlistid>[0-9A-Za-z]+))$'  # noqa: E501
 
     # Spotify URLs are defined at [1]. The assumption is made that they are all
     # pointing to open.spotify.com, so a regex is used to parse them as well,
     # instead of a more complex URL parsing function.
+    # Spotify recently added "/intl-<countrycode>" to their links. This change is undocumented.
+    # There is an assumption that the country code uses the ISO 3166-1 alpha-2 standard [2], 
+    # but this has not been confirmed yet. Spotipy has no use for this, so it gets ignored.
     #
-    # [1] https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids
+    # [1] https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
+    # [2] https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
     _regex_spotify_url = r'^(http[s]?:\/\/)?open.spotify.com\/(intl-\w\w\/)?(?P<type>track|artist|album|playlist|show|episode|user|audiobook)\/(?P<id>[0-9A-Za-z]+)(\?.*)?$'  # noqa: E501
 
     _regex_base62 = r'^[0-9A-Za-z]+$'


### PR DESCRIPTION
closes https://github.com/spotipy-dev/spotipy/issues/1071