### PR TITLE
Fix API Reference

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,9 @@ import os
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath(".."))
+
+import spotipy
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx~=7.3.7
 sphinx-rtd-theme~=2.0.0
+redis>=3.5.3


### PR DESCRIPTION
Since yesterday the API Reference has been empty. RTD's build logs show that the module `spotipy` was not found.
![grafik](https://github.com/spotipy-dev/spotipy/assets/26098388/698c4e7c-bb09-4605-98e7-8303da5a91ee)

One of the reasons for the sudden errors might be bumping sphinx and the removal of `import spotipy` in cc24b4c22fc8d430a66f08ce45be5f0718e12806.

I've built a working documentation on this branch and it seems to work just fine. Not sure how we are going to build a new version of 2.23.0 as RTD had to manually change something to make it work again.