### PR TITLE
Remove obsolete `mock` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Add your changes below.
 -
 
 ### Removed
--
+- `mock` no longer listed as a test dependency. Only built-in `unittest.mock` is actually used.
 
 ## [2.24.0] - 2024-05-30
 

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,11 @@ from setuptools import setup
 with open("README.md") as f:
     long_description = f.read()
 
-test_reqs = [
-    'mock==2.0.0'
-]
-
 memcache_cache_reqs = [
     'pymemcache>=3.5.2'
 ]
 
 extra_reqs = {
-    'test': test_reqs,
     'memcache': memcache_cache_reqs
 }
 
@@ -34,7 +29,6 @@ setup(
         "requests>=2.25.0",
         "urllib3>=1.26.0"
     ],
-    tests_require=test_reqs,
     extras_require=extra_reqs,
     license='MIT',
     packages=['spotipy'])


### PR DESCRIPTION
The package uses `unittest.mock` only, and that one is part of the Python standard library.