### PR TITLE
Move test_track_search to authenticated tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Add your changes below.
 -
 
 ### Fixed
--
+- Fix `test_track_search`, moving it to authenticated tests
 
 ### Removed
 - `mock` no longer listed as a test dependency. Only built-in `unittest.mock` is actually used.

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -355,11 +355,11 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue(results['albums']['items'][0]
                         ['name'].find('Pinkerton') >= 0)
 
-    # def test_track_search(self):
-    #     results = self.spotify.search(q='el scorcho weezer', type='track')
-    #     self.assertTrue('tracks' in results)
-    #     self.assertTrue(len(results['tracks']['items']) > 0)
-    #     self.assertTrue(results['tracks']['items'][0]['name'] == 'El Scorcho')
+    def test_track_search(self):
+        results = self.spotify.search(q='el scorcho weezer', type='track')
+        self.assertTrue('tracks' in results)
+        self.assertTrue(len(results['tracks']['items']) > 0)
+        self.assertTrue(results['tracks']['items'][0]['name'] == 'El Scorcho')
 
     def test_user(self):
         user = self.spotify.user(user='plamere')

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -305,9 +305,9 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertEqual(len(results_limited['AU']['artists']['items']), 2)
         self.assertEqual(len(results_limited['AU']['tracks']['items']), 0)
 
-        item_count = sum([len(market_result['artists']['items']) + len(market_result['tracks']
-                                                                       ['items']) for market_result in
-                          results_limited.values()])
+        item_count = sum([len(market_result['artists']['items'])
+                          + len(market_result['tracks']['items'])
+                          for market_result in results_limited.values()])
 
         self.assertEqual(item_count, total)
 
@@ -363,7 +363,9 @@ class AuthTestSpotipy(unittest.TestCase):
         results = self.spotify.search(q='el scorcho weezer', type='track')
         self.assertTrue('tracks' in results)
         self.assertTrue(len(results['chapters']['items']) > 0)
-        self.assertTrue(results['chapters']['items'][0]['restrictions'] == {"reason": "payment_required"})
+        self.assertTrue(results['chapters']['items'][0]['restrictions'] == {
+            "reason": "payment_required"
+        })
         # self.assertTrue(results['tracks']['items'][0]['name'] == 'El Scorcho')
 
     def test_user(self):

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -361,6 +361,7 @@ class AuthTestSpotipy(unittest.TestCase):
     # https://github.com/spotipy-dev/spotipy/pull/1128
     def test_track_search(self):
         results = self.spotify.search(q='el scorcho weezer', type='track')
+        print("res" + results)
         self.assertTrue('chapters' in results)
         self.assertTrue(len(results['chapters']['items']) > 0)
         self.assertTrue(results['chapters']['items'][0]['restrictions'] == {

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -361,7 +361,7 @@ class AuthTestSpotipy(unittest.TestCase):
     # https://github.com/spotipy-dev/spotipy/pull/1128
     def test_track_search(self):
         results = self.spotify.search(q='el scorcho weezer', type='track')
-        self.assertTrue('tracks' in results)
+        self.assertTrue('chapters' in results)
         self.assertTrue(len(results['chapters']['items']) > 0)
         self.assertTrue(results['chapters']['items'][0]['restrictions'] == {
             "reason": "payment_required"

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -357,6 +357,7 @@ class AuthTestSpotipy(unittest.TestCase):
 
     # Test that the feature doesn't work anymore
     # Currently only works while authenticated, see `tests/integration/user_endpoints`
+    # https://github.com/spotipy-dev/spotipy/pull/1128
     def test_track_search(self):
         results = self.spotify.search(q='el scorcho weezer', type='track')
         self.assertTrue('tracks' in results)

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -262,7 +262,7 @@ class AuthTestSpotipy(unittest.TestCase):
             all(len(results_multiple[country]['artists']['items']) > 0 for country in
                 results_multiple))
         self.assertTrue(all(len(results_all[country]['artists']
-                        ['items']) > 0 for country in results_all))
+                                ['items']) > 0 for country in results_all))
         self.assertTrue(
             all(len(results_tuple[country]['artists']['items']) > 0 for country in results_tuple))
 
@@ -271,9 +271,9 @@ class AuthTestSpotipy(unittest.TestCase):
             all(len(results_multiple[country]['tracks']['items']) > 0 for country in
                 results_multiple))
         self.assertTrue(all(len(results_all[country]['tracks']
-                        ['items']) > 0 for country in results_all))
+                                ['items']) > 0 for country in results_all))
         self.assertTrue(all(len(results_tuple[country]['tracks']
-                        ['items']) > 0 for country in results_tuple))
+                                ['items']) > 0 for country in results_tuple))
 
         # Asserts artist name is the first artist result in all searches
         self.assertTrue(all(results_multiple[country]['artists']['items']
@@ -306,7 +306,8 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertEqual(len(results_limited['AU']['tracks']['items']), 0)
 
         item_count = sum([len(market_result['artists']['items']) + len(market_result['tracks']
-                         ['items']) for market_result in results_limited.values()])
+                                                                       ['items']) for market_result in
+                          results_limited.values()])
 
         self.assertEqual(item_count, total)
 
@@ -361,9 +362,9 @@ class AuthTestSpotipy(unittest.TestCase):
     def test_track_search(self):
         results = self.spotify.search(q='el scorcho weezer', type='track')
         self.assertTrue('tracks' in results)
-        self.assertTrue(len(results['tracks']['items']) > 0)
-        # Change back to == if this test starts failing AKA the feature works again
-        self.assertTrue(results['tracks']['items'][0]['name'] != 'El Scorcho')
+        self.assertTrue(len(results['chapters']['items']) > 0)
+        self.assertTrue(results['chapters']['items'][0]['restrictions'] == {"reason": "payment_required"})
+        # self.assertTrue(results['tracks']['items'][0]['name'] == 'El Scorcho')
 
     def test_user(self):
         user = self.spotify.user(user='plamere')

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -355,6 +355,15 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue(results['albums']['items'][0]
                         ['name'].find('Pinkerton') >= 0)
 
+    # Test that the feature doesn't work anymore
+    # Currently only works while authenticated, see `tests/integration/user_endpoints`
+    def test_track_search(self):
+        results = self.spotify.search(q='el scorcho weezer', type='track')
+        self.assertTrue('tracks' in results)
+        self.assertTrue(len(results['tracks']['items']) > 0)
+        # Change back to == if this test starts failing AKA the feature works again
+        self.assertTrue(results['tracks']['items'][0]['name'] != 'El Scorcho')
+
     def test_user(self):
         user = self.spotify.user(user='plamere')
         self.assertTrue(user['uri'] == 'spotify:user:plamere')

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -361,7 +361,8 @@ class AuthTestSpotipy(unittest.TestCase):
     # https://github.com/spotipy-dev/spotipy/pull/1128
     def test_track_search(self):
         results = self.spotify.search(q='el scorcho weezer', type='track')
-        print("res" + results)
+        print("test results")
+        print(results)
         self.assertTrue('chapters' in results)
         self.assertTrue(len(results['chapters']['items']) > 0)
         self.assertTrue(results['chapters']['items'][0]['restrictions'] == {

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -355,12 +355,6 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue(results['albums']['items'][0]
                         ['name'].find('Pinkerton') >= 0)
 
-    def test_track_search(self):
-        results = self.spotify.search(q='el scorcho weezer', type='track')
-        self.assertTrue('tracks' in results)
-        self.assertTrue(len(results['tracks']['items']) > 0)
-        self.assertTrue(results['tracks']['items'][0]['name'] == 'El Scorcho')
-
     def test_user(self):
         user = self.spotify.user(user='plamere')
         self.assertTrue(user['uri'] == 'spotify:user:plamere')

--- a/tests/integration/non_user_endpoints/test.py
+++ b/tests/integration/non_user_endpoints/test.py
@@ -356,19 +356,11 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue(results['albums']['items'][0]
                         ['name'].find('Pinkerton') >= 0)
 
-    # Test that the feature doesn't work anymore
-    # Currently only works while authenticated, see `tests/integration/user_endpoints`
-    # https://github.com/spotipy-dev/spotipy/pull/1128
     def test_track_search(self):
         results = self.spotify.search(q='el scorcho weezer', type='track')
-        print("test results")
-        print(results)
-        self.assertTrue('chapters' in results)
-        self.assertTrue(len(results['chapters']['items']) > 0)
-        self.assertTrue(results['chapters']['items'][0]['restrictions'] == {
-            "reason": "payment_required"
-        })
-        # self.assertTrue(results['tracks']['items'][0]['name'] == 'El Scorcho')
+        self.assertTrue('tracks' in results)
+        self.assertTrue(len(results['tracks']['items']) > 0)
+        self.assertTrue(results['tracks']['items'][0]['name'] == 'El Scorcho')
 
     def test_user(self):
         user = self.spotify.user(user='plamere')

--- a/tests/integration/user_endpoints/test.py
+++ b/tests/integration/user_endpoints/test.py
@@ -62,6 +62,12 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
     def tearDownClass(cls):
         cls.spotify.current_user_unfollow_playlist(cls.new_playlist['id'])
 
+    def test_track_search(self):
+        results = self.spotify.search(q='el scorcho weezer', type='track')
+        self.assertTrue('tracks' in results)
+        self.assertTrue(len(results['tracks']['items']) > 0)
+        self.assertTrue(results['tracks']['items'][0]['name'] == 'El Scorcho')
+
     def test_user_playlists(self):
         playlists = self.spotify.user_playlists(self.username, limit=5)
         self.assertTrue('items' in playlists)


### PR DESCRIPTION
It appears that searching a track now requires the user to be authenticated
https://github.com/spotipy-dev/spotipy/actions/runs/9321825672/job/25661628355#step:5:73

Possible bug as it's weirdly returning audiobooks 

```json
{
   "authors":[
      {
         "name":"Neil Gaiman"
      }
   ],
   "available_markets":[
      "CA",
      "PR",
      "US"
   ],
   "chapters":{
      "href":"https://api.spotify.com/v1/audiobooks/1IcM9Untg6d3ktuwObYGcN/chapters?offset=0&limit=50&market=US",
      "items":[
         {
            "restrictions":{
               "reason":"payment_required"
            },
            "id":"0e6HmyVq42q68udhfbsbxO",
            "description":"",
            "chapter_number":0,
            "duration_ms":37041,
```

Asked about it here https://community.spotify.com/t5/Spotify-for-Developers/Unauthenticated-track-search-returns-audiobooks-along-with-quot/td-p/6106058