### PR TITLE
Added a Community Section to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Add your changes below.
 
 ### Added
 - Added unit tests for queue functions
+- Added Community Section to README file
 
 ### Fixed
 -

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ If you have suggestions, bugs or other issues specific to this library,
 file them [here](https://github.com/plamere/spotipy/issues).
 Or just send a pull request.
 
+## Community
+
+A strong community is the backbone of any successful open-source project. At Spotipy, we are committed to fostering a welcoming and collaborative environment where developers of all skill levels can come together to share ideas, contribute to the codebase, and support each other. Whether you’re a seasoned contributor or a newcomer, we encourage you to join our discussions on [(https://discord.gg/BjfgKNeJ)] to participate in our feature requests and bug reports, and engage with fellow users and developers. 
+
 ## Contributing
 
 If you are a developer with Python experience, and you would like to contribute to Spotipy, please be sure to follow the guidelines listed on documentation page


### PR DESCRIPTION
In the README file, I added a “Community” section. I provided brief description for the justification and purpose of a community for this project. I also included a link to the external Discord server that I made. I did not change other files or create other files for the project. As of right now, the project directs users to go to Stack Overflow or issues page on Github for reporting issues. However, I noticed that it is common for larger projects to have either a discussion forum or slack channel for members to convene whether to ask questions or share ideas within the space. With some variation of community for contributors, it should improve the sharing of ideas and collaborations. It would be a more low stake and low pressure environment for contributors which in turn may encourage more participation especially from newer developers. Overall, I believe it would benefit the project in the long run.