### PR TITLE
Print warnings when a rate/request limit is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Add your changes below.
 
 ### Added
 - Added unit tests for queue functions
+- Added custom `urllib3.Retry` class for printing a warning when a rate/request limit is reached.
 
 ### Fixed
 -

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -11,6 +11,7 @@ import requests
 import urllib3
 
 from spotipy.exceptions import SpotifyException
+from spotipy.util import Retry
 
 from collections import defaultdict
 
@@ -220,7 +221,7 @@ class Spotify:
 
     def _build_session(self):
         self._session = requests.Session()
-        retry = urllib3.Retry(
+        retry = Retry(
             total=self.retries,
             connect=None,
             read=False,

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -131,3 +131,17 @@ def normalize_scope(scope):
         return " ".join(sorted(scopes))
     else:
         return None
+
+
+class Retry(urllib3.Retry):
+    """
+    Custom class for printing a warning when a rate/request limit is reached.
+    """
+    def is_retry(
+        self, method: str, status_code: int, has_retry_after: bool = False
+    ) -> bool:
+        retry = super().is_retry(method, status_code, has_retry_after)
+        if retry:
+            # message could be more "professional", but it's good enough for now
+            logging.warning("Your application has reached a rate/request limit")
+        return retry


### PR DESCRIPTION
I'm writing this sentence a fifth time. Does what the title says.

This is still a draft because I'm still researching how to implement this so we can get the retry-after value right away.
Currently it only prints a warning (whose text could be improved as well)