### PR TITLE
Add SpotifyBaseException and move all exceptions to exceptions.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Add your changes below.
 - Added custom `urllib3.Retry` class for printing a warning when a rate/request limit is reached.
 - Added `personalized_playlist.py`, `track_recommendations.py`, and `audio_features_analysis.py` to `/examples`.
 - Discord badge in README
+- Added `SpotifyBaseException` and moved all exceptions to `exceptions.py`
 
 ### Fixed
 - Audiobook integration tests

--- a/spotipy/exceptions.py
+++ b/spotipy/exceptions.py
@@ -1,4 +1,8 @@
-class SpotifyException(Exception):
+class SpotifyBaseException(Exception):
+    pass
+
+
+class SpotifyException(SpotifyBaseException):
 
     def __init__(self, http_status, code, msg, reason=None, headers=None):
         self.http_status = http_status
@@ -14,3 +18,26 @@ class SpotifyException(Exception):
     def __str__(self):
         return 'http status: {}, code:{} - {}, reason: {}'.format(
             self.http_status, self.code, self.msg, self.reason)
+
+
+class SpotifyOauthError(SpotifyBaseException):
+    """ Error during Auth Code or Implicit Grant flow """
+
+    def __init__(self, message, error=None, error_description=None, *args, **kwargs):
+        self.error = error
+        self.error_description = error_description
+        self.__dict__.update(kwargs)
+        super().__init__(message, *args, **kwargs)
+
+
+class SpotifyStateError(SpotifyOauthError):
+    """ The state sent and state received were different """
+
+    def __init__(self, local_state=None, remote_state=None, message=None,
+                 error=None, error_description=None, *args, **kwargs):
+        if not message:
+            message = ("Expected " + local_state + " but received "
+                       + remote_state)
+        super(SpotifyOauthError, self).__init__(message, error,
+                                                error_description, *args,
+                                                **kwargs)

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -20,32 +20,10 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qsl, urlparse
 
 from spotipy.cache_handler import CacheFileHandler, CacheHandler
+from spotipy.exceptions import SpotifyOauthError, SpotifyStateError
 from spotipy.util import CLIENT_CREDS_ENV_VARS, get_host_port, normalize_scope
 
 logger = logging.getLogger(__name__)
-
-
-class SpotifyOauthError(Exception):
-    """ Error during Auth Code or Implicit Grant flow """
-
-    def __init__(self, message, error=None, error_description=None, *args, **kwargs):
-        self.error = error
-        self.error_description = error_description
-        self.__dict__.update(kwargs)
-        super().__init__(message, *args, **kwargs)
-
-
-class SpotifyStateError(SpotifyOauthError):
-    """ The state sent and state received were different """
-
-    def __init__(self, local_state=None, remote_state=None, message=None,
-                 error=None, error_description=None, *args, **kwargs):
-        if not message:
-            message = ("Expected " + local_state + " but received "
-                       + remote_state)
-        super(SpotifyOauthError, self).__init__(message, error,
-                                                error_description, *args,
-                                                **kwargs)
 
 
 def _make_authorization_headers(client_id, client_secret):


### PR DESCRIPTION
This should be backwards compatible by importing the oauth errors back into the `oauth2.py` file.
Closes #1160 