### PR TITLE
Troubleshooting aid for headless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Add your changes below.
 - Added `personalized_playlist.py`, `track_recommendations.py`, and `audio_features_analysis.py` to `/examples`.
 - Discord badge in README
 - Added `SpotifyBaseException` and moved all exceptions to `exceptions.py`
+- Added note about browser troubleshooting to the headless.py example
 
 ### Fixed
 - Audiobook integration tests

--- a/examples/headless.py
+++ b/examples/headless.py
@@ -3,6 +3,7 @@ import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 
 # set open_browser=False to prevent Spotipy from attempting to open the default browser
+# Note that some browsers might hide the URL redirected to, if this happens test another browser
 spotify = spotipy.Spotify(auth_manager=SpotifyOAuth(open_browser=False))
 
 print(spotify.me())


### PR DESCRIPTION
While trying to use headless mode on a raspberry pi from a Mac I noticed that safari does not properly handle the redirect from the authentication page. This gave that the url in the address field never got updated to the one with the credential token. Testing the same flow and settings in firefox worked directly. 

Added this small note to help other developers potentially avoid to also get stuck for too long on this thing :) 