### PR TITLE
add additional_types to current_user_playing_track()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Add your changes below.
 
 ### Added
 
+- Adds `additional_types` parameter to retrieve currently playing episode
+
 ### Fixed
 
 ### Removed

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1256,10 +1256,20 @@ class Spotify:
         """
         return self.me()
 
-    def current_user_playing_track(self):
+    def current_user_playing_track(self, market=None, additional_types=("track",)):
         """ Get information about the current users currently playing track.
+
+            Parameters:
+                - market - An ISO 3166-1 alpha-2 country code or the
+                           string from_token.
+                - additional_types - list of item types to return.
+                                     valid types are: track and episode
         """
-        return self._get("me/player/currently-playing")
+        return self._get(
+            "me/player/currently-playing",
+            market=market,
+            additional_types=",".join(additional_types)
+        )
 
     def current_user_saved_albums(self, limit=20, offset=0, market=None):
         """ Gets a list of the albums saved in the current authorized user's


### PR DESCRIPTION
The new Spotify audiobook feature plays as episodes not as tracks.