### PR TITLE
Correct Spotify/Spotipy typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Add your changes below.
 ### Fixed
 
 - Fixed dead link in README.md
+- Corrected Spotify/Spotipy typo in documentation
 
 ### Removed
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Install or upgrade *Spotipy* with::
 
     pip install spotipy --upgrade
 
-You can also obtain the source code from the `Spotify GitHub repository <https://github.com/plamere/spotipy>`_.
+You can also obtain the source code from the `Spotipy GitHub repository <https://github.com/plamere/spotipy>`_.
 
 
 Getting Started


### PR DESCRIPTION
Correct Spotify/Spotipy typo. Document refers the user to the "Spotify GitHub repository" while the associated link is actually to the Spotipy GitHub repo.